### PR TITLE
feat(button_group): add button group component with styling and examples

### DIFF
--- a/src/components/button.mbt
+++ b/src/components/button.mbt
@@ -49,7 +49,7 @@ pub fn[M] button(
   color~ : @theme.ButtonColor = @theme.Primary,
   fullWidth~ : Bool = false,
   ripple~ : Bool = true,
-  className~ : String? = None
+  className~ : String? = None,
 ) -> @html.Html[M] {
   let klass = @theme.get_button_style(
     variant~,

--- a/src/components/button_group.mbt
+++ b/src/components/button_group.mbt
@@ -1,0 +1,77 @@
+///|
+/// Creates a configurable button group component that groups multiple buttons
+/// together with consistent styling and behavior.
+///
+/// Parameters:
+///
+/// * `children` : Array[@html.Html[M]] - The button elements to group together.
+/// * `variant` : @theme.ButtonGroupVariant - The visual style variant for all buttons.
+///   Defaults to `@theme.Solid`.
+/// * `size` : @theme.ButtonGroupSize - The size for all buttons. Defaults to
+///   `@theme.Md`.
+/// * `color` : @theme.ButtonGroupColor - The color theme for all buttons. Defaults to
+///   `@theme.Primary`.
+/// * `orientation` : @theme.ButtonGroupOrientation - The layout orientation.
+///   Defaults to `@theme.Horizontal`.
+/// * `fullWidth` : Bool - Whether the button group should take the full width.
+///   Defaults to `false`.
+/// * `ripple` : Bool - Whether to enable ripple effect on button interactions.
+///   Defaults to `true`.
+/// * `isPill` : Bool - Whether buttons should have pill-shaped corners.
+///   Defaults to `false`.
+/// * `class` : String? - Additional CSS class name to apply to the group.
+///   Defaults to `None`.
+///
+/// Returns an HTML div element containing the grouped buttons with appropriate
+/// styling for seamless connection.
+///
+/// Example:
+///
+/// ```moonbit skip
+/// enum Msg {
+///   FirstAction
+///   SecondAction
+///   ThirdAction
+/// }
+/// 
+/// let buttons = [
+///   button([text("First")], FirstAction),
+///   button([text("Second")], SecondAction),
+///   button([text("Third")], ThirdAction)
+/// ]
+/// 
+/// let _ = button_group(
+///   buttons,
+///   variant=Outlined,
+///   size=Lg,
+///   color=Primary,
+///   orientation=Horizontal
+/// )
+/// ```
+///
+pub fn[M] button_group(
+  children : Array[@html.Html[M]],
+  orientation~ : @theme.ButtonGroupOrientation = @theme.Horizontal,
+  fullWidth~ : Bool = false,
+  class~ : String? = None,
+) -> @html.Html[M] {
+  let klass = @theme.get_button_group_style(orientation~, fullWidth~, class~)
+  // let variant_str = match variant {
+  //   @theme.Ghost => "ghost"
+  //   @theme.Outlined => "outlined"
+  //   @theme.Solid => "solid"
+  //   @theme.Gradient => "gradient"
+  // }
+  // let orientation_str = match orientation {
+  //   @theme.Horizontal => "horizontal"
+  //   @theme.Vertical => "vertical"
+  // }
+  // let attrs = [
+  //   @html.attribute("class", klass),
+  //   @html.attribute("data-variant", variant_str),
+  //   @html.attribute("data-orientation", orientation_str),
+  //   @html.attribute("data-shape", if isPill { "pill" } else { "default" }),
+  //   @html.attribute("data-width", if fullWidth { "full" } else { "default" }),
+  // ]
+  @html.div(class=klass, children)
+}

--- a/src/components/card.mbt
+++ b/src/components/card.mbt
@@ -30,7 +30,7 @@ pub fn[M] card(
   children : Array[@html.Html[M]],
   variant~ : @theme.CardVariant = Solid,
   color~ : @theme.CardColor = Default,
-  className~ : String? = None
+  className~ : String? = None,
 ) -> Html[M] {
   let card_style = @theme.get_card_style(variant~, color~, className~)
   let attrs = [@html.attribute("class", card_style)]
@@ -61,7 +61,7 @@ pub fn[M] card(
 ///
 pub fn[M] card_header(
   children : Array[@html.Html[M]],
-  className~ : String? = None
+  className~ : String? = None,
 ) -> Html[M] {
   let header_style = @theme.get_card_header_style(className~)
   let attrs = [@html.attribute("class", header_style)]
@@ -95,7 +95,7 @@ pub fn[M] card_header(
 ///
 pub fn[M] card_body(
   children : Array[@html.Html[M]],
-  className~ : String? = None
+  className~ : String? = None,
 ) -> Html[M] {
   let body_style = @theme.get_card_body_style(className~)
   @html.div(class=body_style, children)
@@ -126,7 +126,7 @@ pub fn[M] card_body(
 ///
 pub fn[M] card_footer(
   children : Array[@html.Html[M]],
-  className~ : String? = None
+  className~ : String? = None,
 ) -> Html[M] {
   let footer_style = @theme.get_card_footer_style(className~)
   @html.div(class=footer_style, children)

--- a/src/components/components.mbti
+++ b/src/components/components.mbti
@@ -1,3 +1,4 @@
+// Generated using `moon info`, DON'T EDIT IT
 package "Yoorkin/jade_ui/components"
 
 import(
@@ -7,6 +8,8 @@ import(
 
 // Values
 fn[M] button(Array[@html.Html[M]], M, variant~ : @theme.ButtonVariant = .., size~ : @theme.ButtonSize = .., color~ : @theme.ButtonColor = .., fullWidth~ : Bool = .., ripple~ : Bool = .., className~ : String? = ..) -> @html.Html[M]
+
+fn[M] button_group(Array[@html.Html[M]], orientation~ : @theme.ButtonGroupOrientation = .., fullWidth~ : Bool = .., class~ : String? = ..) -> @html.Html[M]
 
 fn[M] card(Array[@html.Html[M]], variant~ : @theme.CardVariant = .., color~ : @theme.CardColor = .., className~ : String? = ..) -> @html.Html[M]
 

--- a/src/components/slider.mbt
+++ b/src/components/slider.mbt
@@ -7,7 +7,7 @@ pub fn[M] slider(
   color~ : @theme.SliderColor = Primary,
   size~ : @theme.SliderSize = Md,
   class~ : String = "",
-  childrens? : Array[Html[M]]
+  childrens? : Array[Html[M]],
 ) -> Html[M] {
   // ensure value is in range
   let clamped_value = if value < min {

--- a/src/components/typography.mbt
+++ b/src/components/typography.mbt
@@ -3,7 +3,7 @@ pub fn[M] typography(
   tag~ : @theme.TypographyType = @theme.P,
   color~ : @theme.TypographyColor = @theme.Inherit,
   class~ : String = "",
-  children : Array[@html.Html[M]]
+  children : Array[@html.Html[M]],
 ) -> @html.Html[M] {
   let style = @theme.get_typography_style(tag, color, class)
   match tag {

--- a/src/example/example.mbti
+++ b/src/example/example.mbti
@@ -1,3 +1,4 @@
+// Generated using `moon info`, DON'T EDIT IT
 package "Yoorkin/jade_ui/example"
 
 // Values

--- a/src/example/main.mbt
+++ b/src/example/main.mbt
@@ -43,8 +43,241 @@ fn view(model : Model) -> Html[Msg] {
       ]),
     ]),
 
+    // Button Group showcase
+    div(class="max-w-6xl mx-auto mb-12", [
+      h2(class="text-2xl font-bold mb-6 text-gray-800", [
+        text("Button Group Component"),
+      ]),
+
+      // Horizontal Button Groups
+      div(class="mb-8", [
+        h3(class="text-lg font-semibold mb-4 text-gray-700", [
+          text("Horizontal Button Groups"),
+        ]),
+        div(class="space-y-4", [
+          // Solid variant
+          div([
+            h4(class="text-md font-medium mb-2 text-gray-600", [
+              text("Solid Variant"),
+            ]),
+            @jade.button_group(
+              [
+                @jade.button(
+                  [text("First")],
+                  Increment,
+                  variant=@theme.Solid,
+                  color=@theme.Primary,
+                ),
+                @jade.button(
+                  [text("Second")],
+                  Increment,
+                  variant=@theme.Solid,
+                  color=@theme.Primary,
+                ),
+                @jade.button(
+                  [text("Third")],
+                  Increment,
+                  variant=@theme.Solid,
+                  color=@theme.Primary,
+                ),
+              ],
+              orientation=@theme.Horizontal,
+            ),
+          ]),
+          // Outlined variant
+          div([
+            h4(class="text-md font-medium mb-2 text-gray-600", [
+              text("Outlined Variant"),
+            ]),
+            @jade.button_group(
+              [
+                @jade.button(
+                  [text("Left")],
+                  Increment,
+                  variant=@theme.Outlined,
+                  color=@theme.Secondary,
+                ),
+                @jade.button(
+                  [text("Center")],
+                  Increment,
+                  variant=@theme.Outlined,
+                  color=@theme.Secondary,
+                ),
+                @jade.button(
+                  [text("Right")],
+                  Increment,
+                  variant=@theme.Outlined,
+                  color=@theme.Secondary,
+                ),
+              ],
+              orientation=@theme.Horizontal,
+            ),
+          ]),
+          // Ghost variant
+          div([
+            h4(class="text-md font-medium mb-2 text-gray-600", [
+              text("Ghost Variant"),
+            ]),
+            @jade.button_group(
+              [
+                @jade.button(
+                  [text("Option A")],
+                  Increment,
+                  variant=@theme.Ghost,
+                  color=@theme.Info,
+                ),
+                @jade.button(
+                  [text("Option B")],
+                  Increment,
+                  variant=@theme.Ghost,
+                  color=@theme.Info,
+                ),
+                @jade.button(
+                  [text("Option C")],
+                  Increment,
+                  variant=@theme.Ghost,
+                  color=@theme.Info,
+                ),
+              ],
+              orientation=@theme.Horizontal,
+            ),
+          ]),
+        ]),
+      ]),
+
+      // Vertical Button Groups
+      div(class="mb-8", [
+        h3(class="text-lg font-semibold mb-4 text-gray-700", [
+          text("Vertical Button Groups"),
+        ]),
+        div(class="flex gap-8", [
+          div([
+            h4(class="text-md font-medium mb-2 text-gray-600", [
+              text("Solid Vertical"),
+            ]),
+            @jade.button_group(
+              [
+                @jade.button(
+                  [text("Top")],
+                  Increment,
+                  variant=@theme.Solid,
+                  color=@theme.Success,
+                ),
+                @jade.button(
+                  [text("Middle")],
+                  Increment,
+                  variant=@theme.Solid,
+                  color=@theme.Success,
+                ),
+                @jade.button(
+                  [text("Bottom")],
+                  Increment,
+                  variant=@theme.Solid,
+                  color=@theme.Success,
+                ),
+              ],
+              orientation=@theme.Vertical,
+            ),
+          ]),
+          div([
+            h4(class="text-md font-medium mb-2 text-gray-600", [
+              text("Outlined Vertical"),
+            ]),
+            @jade.button_group(
+              [
+                @jade.button(
+                  [text("First")],
+                  Increment,
+                  variant=@theme.Outlined,
+                  color=@theme.Warning,
+                ),
+                @jade.button(
+                  [text("Second")],
+                  Increment,
+                  variant=@theme.Outlined,
+                  color=@theme.Warning,
+                ),
+                @jade.button(
+                  [text("Third")],
+                  Increment,
+                  variant=@theme.Outlined,
+                  color=@theme.Warning,
+                ),
+              ],
+              orientation=@theme.Vertical,
+            ),
+          ]),
+        ]),
+      ]),
+
+      // Button Group Sizes
+      div(class="mb-8", [
+        h3(class="text-lg font-semibold mb-4 text-gray-700", [
+          text("Button Group Sizes"),
+        ]),
+        div(class="space-y-4", [
+          div([
+            h4(class="text-md font-medium mb-2 text-gray-600", [
+              text("Small Size"),
+            ]),
+            @jade.button_group([
+              @jade.button(
+                [text("Small")],
+                Increment,
+                variant=@theme.Solid,
+                color=@theme.Primary,
+                size=@theme.Sm,
+              ),
+              @jade.button(
+                [text("Button")],
+                Increment,
+                variant=@theme.Solid,
+                color=@theme.Primary,
+                size=@theme.Sm,
+              ),
+              @jade.button(
+                [text("Group")],
+                Increment,
+                variant=@theme.Solid,
+                color=@theme.Primary,
+                size=@theme.Sm,
+              ),
+            ]),
+          ]),
+          div([
+            h4(class="text-md font-medium mb-2 text-gray-600", [
+              text("Large Size"),
+            ]),
+            @jade.button_group([
+              @jade.button(
+                [text("Large")],
+                Increment,
+                variant=@theme.Solid,
+                color=@theme.Primary,
+                size=@theme.Lg,
+              ),
+              @jade.button(
+                [text("Button")],
+                Increment,
+                variant=@theme.Solid,
+                color=@theme.Primary,
+                size=@theme.Lg,
+              ),
+              @jade.button(
+                [text("Group")],
+                Increment,
+                variant=@theme.Solid,
+                color=@theme.Primary,
+                size=@theme.Lg,
+              ),
+            ]),
+          ]),
+        ]),
+      ]),
+    ]),
+
     // Button style showcase
-    div(class="max-w-7xl mx-auto mb-12", [
+    div(class="max-w-6xl mx-auto mb-12", [
       h2(class="text-2xl font-bold mb-6 text-gray-800", [
         text("Button Component Styles"),
       ]),

--- a/src/theme/button.mbt
+++ b/src/theme/button.mbt
@@ -32,7 +32,7 @@ pub fn get_button_style(
   color~ : ButtonColor,
   fullWidth~ : Bool,
   ripple~ : Bool,
-  className~ : String?
+  className~ : String?,
 ) -> String {
   clsx([
     "cursor-pointer inline-flex items-center justify-center border align-middle select-none font-sans font-medium text-center transition-all duration-300 ease-in disabled:opacity-50 disabled:shadow-none disabled:cursor-not-allowed data-[shape=pill]:rounded-full data-[width=full]:w-full focus:shadow-none",

--- a/src/theme/button_group.mbt
+++ b/src/theme/button_group.mbt
@@ -1,0 +1,74 @@
+///|
+pub(all) enum ButtonGroupOrientation {
+  Horizontal
+  Vertical
+}
+
+///|
+pub(all) enum ButtonGroupVariant {
+  Ghost
+  Outlined
+  Solid
+  Gradient
+}
+
+///|
+pub(all) enum ButtonGroupSize {
+  Xs
+  Sm
+  Md
+  Lg
+  Xl
+}
+
+///|
+pub(all) enum ButtonGroupColor {
+  Primary
+  Secondary
+  Accent
+  Neutral
+  Base
+  Info
+  Success
+  Warning
+  Error
+}
+
+///|
+pub fn get_button_group_style(
+  orientation~ : ButtonGroupOrientation,
+  fullWidth~ : Bool,
+  class~ : String?,
+) -> String {
+  clsx([
+    "inline-flex",
+    // Full width style
+    if fullWidth {
+      "w-full"
+    } else {
+      ""
+    },
+    // Orientation styles
+    match orientation {
+      Horizontal =>
+        clsx([
+          "flex-row",
+          // Remove borders and round corners for middle buttons
+           "[&>*:not(:first-child):not(:last-child)]:rounded-none", "[&>*:first-child]:rounded-r-none",
+          "[&>*:last-child]:rounded-l-none", "[&>*:not(:first-child)]:border-l-0",
+        ])
+      Vertical =>
+        clsx([
+          "flex-col",
+          // Remove borders and round corners for middle buttons
+           "[&>*:not(:first-child):not(:last-child)]:rounded-none", "[&>*:first-child]:rounded-b-none",
+          "[&>*:last-child]:rounded-t-none", "[&>*:not(:first-child)]:border-t-0",
+        ])
+    },
+    // Optional custom class name
+    match class {
+      Some(cls) => cls
+      None => ""
+    },
+  ])
+}

--- a/src/theme/card.mbt
+++ b/src/theme/card.mbt
@@ -21,7 +21,7 @@ pub(all) enum CardColor {
 pub fn get_card_style(
   variant~ : CardVariant,
   color~ : CardColor,
-  className~ : String?
+  className~ : String?,
 ) -> String {
   clsx([
     // Base styles

--- a/src/theme/slider.mbt
+++ b/src/theme/slider.mbt
@@ -59,7 +59,7 @@ pub fn get_slider_classes(class : String) -> String {
 pub fn get_slider_styles(
   thumb_height : Int,
   color_value : String,
-  progress_percent : Double
+  progress_percent : Double,
 ) -> Array[String] {
   [
     "--range-bg: color-mix(in oklab,currentColor 10%, transparent)",

--- a/src/theme/theme.mbt
+++ b/src/theme/theme.mbt
@@ -161,7 +161,7 @@ pub fn JadeTheme::to_styles(self : JadeTheme) -> Map[String, String] {
 
 ///|
 pub fn[M] JadeTheme::to_attributes(
-  self : JadeTheme
+  self : JadeTheme,
 ) -> Array[@html.Attribute[M]] {
   self.to_styles().iter().map(x => @html.style(x.0, x.1)).to_array()
 }

--- a/src/theme/theme.mbti
+++ b/src/theme/theme.mbti
@@ -1,3 +1,4 @@
+// Generated using `moon info`, DON'T EDIT IT
 package "Yoorkin/jade_ui/theme"
 
 import(
@@ -7,6 +8,8 @@ import(
 
 // Values
 fn clsx(Array[String]) -> String
+
+fn get_button_group_style(orientation~ : ButtonGroupOrientation, fullWidth~ : Bool, class~ : String?) -> String
 
 fn get_button_style(variant~ : ButtonVariant, size~ : ButtonSize, color~ : ButtonColor, fullWidth~ : Bool, ripple~ : Bool, className~ : String?) -> String
 
@@ -38,6 +41,38 @@ pub(all) enum ButtonColor {
   Success
   Warning
   Error
+}
+
+pub(all) enum ButtonGroupColor {
+  Primary
+  Secondary
+  Accent
+  Neutral
+  Base
+  Info
+  Success
+  Warning
+  Error
+}
+
+pub(all) enum ButtonGroupOrientation {
+  Horizontal
+  Vertical
+}
+
+pub(all) enum ButtonGroupSize {
+  Xs
+  Sm
+  Md
+  Lg
+  Xl
+}
+
+pub(all) enum ButtonGroupVariant {
+  Ghost
+  Outlined
+  Solid
+  Gradient
 }
 
 pub(all) enum ButtonSize {

--- a/src/theme/typography.mbt
+++ b/src/theme/typography.mbt
@@ -27,7 +27,7 @@ pub(all) enum TypographyColor {
 pub fn get_typography_style(
   typography_type : TypographyType,
   color : TypographyColor,
-  class : String
+  class : String,
 ) -> String {
   let base_style = "font-sans antialiased"
   let type_style = match typography_type {


### PR DESCRIPTION
Add new button group component that groups buttons together with consistent styling. Includes:
- Horizontal and vertical orientation support
- Various styling variants (solid, outlined, ghost)
- Size variations
- Example showcase in main.mbt
- 
<img width="714" height="1698" alt="image" src="https://github.com/user-attachments/assets/8dbbd3cf-88d1-46e8-8148-4908467ac543" />
