### PR TITLE
feat(components): add spinner component with size and color variants

### DIFF
--- a/src/components/pkg.generated.mbti
+++ b/src/components/pkg.generated.mbti
@@ -49,6 +49,8 @@ fn[M] menu_trigger(Array[@html.Html[M]], M, isOpen? : Bool, color? : @theme.Menu
 
 fn[M] slider(value? : Int, min? : Int, max? : Int, on_input~ : (Int) -> M, color? : @theme.SliderColor, size? : @theme.SliderSize, class? : String, children? : Array[@html.Html[M]]) -> @html.Html[M]
 
+fn[M] spinner(size? : @theme.SpinnerSize, color? : @theme.SpinnerColor, class? : String) -> @html.Html[M]
+
 fn[M] switch(checked? : Bool, change~ : M, color? : @theme.SwitchColor, className? : String?, id? : String?) -> @html.Html[M]
 
 fn[M] tabs(Array[@html.Html[M]], orientation? : @theme.TabsOrientation, class? : String?) -> @html.Html[M]

--- a/src/components/spinner.mbt
+++ b/src/components/spinner.mbt
@@ -1,0 +1,53 @@
+// Spinner component for loading states
+
+// Spinner component with configurable size and color
+
+///|
+pub fn[M] spinner(
+  size? : @theme.SpinnerSize = Md,
+  color? : @theme.SpinnerColor = Primary,
+  class? : String,
+) -> @html.Html[M] {
+  let spinner_style = @theme.get_spinner_style(size~, color~, class?)
+  let stroke_style = @theme.get_spinner_stroke_style(color~)
+  @svg.node(
+    "svg",
+    [
+      @svg.attribute("class", spinner_style),
+      @svg.attribute("fill", "none"),
+      @svg.attribute("viewBox", "0 0 64 64"),
+      @svg.attribute("xmlns", "http://www.w3.org/2000/svg"),
+    ],
+    [
+      // Background circle (lighter color)
+      @svg.node(
+        "path",
+        [
+          @svg.attribute("stroke", "currentColor"),
+          @svg.attribute("stroke-width", "5"),
+          @svg.attribute("stroke-linecap", "round"),
+          @svg.attribute("stroke-linejoin", "round"),
+          @svg.attribute("class", stroke_style),
+          @svg.attribute(
+            "d", "M32 3C35.8083 3 39.5794 3.75011 43.0978 5.20749C46.6163 6.66488 49.8132 8.80101 52.5061 11.4939C55.199 14.1868 57.3351 17.3837 58.7925 20.9022C60.2499 24.4206 61 28.1917 61 32C61 35.8083 60.2499 39.5794 58.7925 43.0978C57.3351 46.6163 55.199 49.8132 52.5061 52.5061C49.8132 55.199 46.6163 57.3351 43.0978 58.7925C39.5794 60.2499 35.8083 61 32 61C28.1917 61 24.4206 60.2499 20.9022 58.7925C17.3837 57.3351 14.1868 55.199 11.4939 52.5061C8.801 49.8132 6.66487 46.6163 5.20749 43.0978C3.7501 39.5794 3 35.8083 3 32C3 28.1917 3.75011 24.4206 5.2075 20.9022C6.66489 17.3837 8.80101 14.1868 11.4939 11.4939C14.1868 8.80099 17.3838 6.66487 20.9022 5.20749C24.4206 3.7501 28.1917 3 32 3L32 3Z",
+          ),
+        ],
+        [],
+      ),
+      // Animated arc (full color)
+      @svg.node(
+        "path",
+        [
+          @svg.attribute("stroke-width", "5"),
+          @svg.attribute("stroke-linecap", "round"),
+          @svg.attribute("stroke-linejoin", "round"),
+          @svg.attribute("stroke", "currentColor"),
+          @svg.attribute(
+            "d", "M32 3C36.5778 3 41.0906 4.08374 45.1692 6.16256C49.2477 8.24138 52.7762 11.2562 55.466 14.9605C58.1558 18.6647 59.9304 22.9531 60.6448 27.4748C61.3591 31.9965 60.9928 36.6232 59.5759 40.9762",
+          ),
+        ],
+        [],
+      ),
+    ],
+  ).0
+}

--- a/src/example/main.mbt
+++ b/src/example/main.mbt
@@ -2178,19 +2178,16 @@ fn render_tabs_section(model : Model) -> Html[Msg] {
     @jade.card(
       [
         @jade.card_header([
-          @jade.typography(tag=@theme.H2, color=@theme.Default, [
+          @jade.typography(tag=H2, color=Default, [
             text("Tabs Component Styles"),
           ]),
         ]),
         @jade.card_body(
           [
-            @jade.typography(
-              tag=@theme.H3,
-              color=@theme.Default,
-              class="mb-4",
-              [text("Tab Variants")],
-            ),
-            ..variants.map(variant => @html.div(class="space-y-8", [
+            @jade.typography(tag=H3, color=Default, class="mb-4", [
+              text("Tab Variants"),
+            ]),
+            ..variants.map(variant => div(class="space-y-8", [
               // Default 变体
               @jade.card(
                 [
@@ -2311,6 +2308,65 @@ fn render_tabs_section(model : Model) -> Html[Msg] {
             color=Error,
             variant=Gradient,
           ),
+        ]),
+      ]),
+    ]),
+    // Spinner component showcase
+    div(class="mb-8", [
+      h3(class="text-lg font-semibold mb-4 text-gray-700", [
+        text("Spinner Component"),
+      ]),
+
+      // Spinner colors
+      div(class="mb-8", [
+        h3(class="text-lg font-semibold mb-4 text-gray-700", [
+          text("Spinner Colors"),
+        ]),
+        div(class="flex flex-wrap gap-4", [
+          @jade.spinner(color=Primary),
+          @jade.spinner(color=Secondary),
+          @jade.spinner(color=Info),
+          @jade.spinner(color=Success),
+          @jade.spinner(color=Warning),
+          @jade.spinner(color=Error),
+        ]),
+      ]),
+
+      // Spinner sizes
+      div(class="mb-8", [
+        h3(class="text-lg font-semibold mb-4 text-gray-700", [
+          text("Spinner Sizes"),
+        ]),
+        div(class="flex items-center gap-6 flex-wrap", [
+          @jade.spinner(size=Xs),
+          @jade.spinner(size=Sm),
+          @jade.spinner(size=Md),
+          @jade.spinner(size=Lg),
+          @jade.spinner(size=Xl),
+        ]),
+      ]),
+
+      // Spinner in context
+      div(class="mb-6", [
+        h4(class="text-md font-medium mb-3 text-gray-600", [text("In Context")]),
+        div(class="bg-white rounded-lg p-6 shadow-sm", [
+          div(class="flex flex-col gap-4", [
+            // Loading button
+            div(class="flex items-center gap-3", [
+              @jade.spinner(),
+              @html.p(class="text-gray-700", [text("Loading...")]),
+            ]),
+            // Loading card
+            div(
+              class="border rounded-lg p-4 flex items-center justify-center",
+              [
+                div(class="flex flex-col items-center gap-3", [
+                  @jade.spinner(),
+                  @html.p(class="text-gray-600", [text("Fetching data...")]),
+                ]),
+              ],
+            ),
+          ]),
         ]),
       ]),
     ]),

--- a/src/theme/pkg.generated.mbti
+++ b/src/theme/pkg.generated.mbti
@@ -65,6 +65,10 @@ fn get_slider_styles(Int, String, Double) -> Array[String]
 
 fn get_slider_thumb_height(SliderSize) -> Int
 
+fn get_spinner_stroke_style(color~ : SpinnerColor) -> String
+
+fn get_spinner_style(size~ : SpinnerSize, color~ : SpinnerColor, class? : String) -> String
+
 fn get_switch_color_classes(SwitchColor) -> String
 
 fn get_switch_style(color~ : SwitchColor, className~ : String?) -> String
@@ -293,6 +297,24 @@ pub(all) enum SliderSize {
   Md
   Lg
   Xl
+}
+
+pub(all) enum SpinnerColor {
+  Primary
+  Secondary
+  Success
+  Warning
+  Error
+  Info
+}
+
+pub(all) enum SpinnerSize {
+  Xs
+  Sm
+  Md
+  Lg
+  Xl
+  Xxl
 }
 
 pub(all) enum SwitchColor {

--- a/src/theme/spinner.mbt
+++ b/src/theme/spinner.mbt
@@ -1,0 +1,67 @@
+// Spinner component theme configuration
+
+// Spinner size variants
+
+///|
+pub(all) enum SpinnerSize {
+  Xs
+  Sm
+  Md
+  Lg
+  Xl
+  Xxl
+}
+
+// Spinner color variants (reusing existing color system from JadeTheme)
+
+///|
+pub(all) enum SpinnerColor {
+  Primary
+  Secondary
+  Success
+  Warning
+  Error
+  Info
+}
+
+// Generate CSS classes for spinner styling
+
+///|
+pub fn get_spinner_style(
+  size~ : SpinnerSize,
+  color~ : SpinnerColor,
+  class? : String = "",
+) -> String {
+  let size_classes = match size {
+    Xs => "w-4 h-4"
+    Sm => "w-6 h-6"
+    Md => "w-8 h-8"
+    Lg => "w-10 h-10"
+    Xl => "w-12 h-12"
+    Xxl => "w-16 h-16"
+  }
+  let color_classes = match color {
+    Primary => "text-[var(--color-primary)]"
+    Secondary => "text-[var(--color-secondary)]"
+    Success => "text-[var(--color-success)]"
+    Warning => "text-[var(--color-warning)]"
+    Error => "text-[var(--color-error)]"
+    Info => "text-[var(--color-info)]"
+  }
+  let base_classes = "animate-spin"
+  clsx([base_classes, size_classes, color_classes, class])
+}
+
+// Generate CSS classes for spinner stroke color
+
+///|
+pub fn get_spinner_stroke_style(color~ : SpinnerColor) -> String {
+  match color {
+    Primary => "stroke-[var(--color-primary)]/20"
+    Secondary => "stroke-[var(--color-secondary)]/20"
+    Success => "stroke-[var(--color-success)]/20"
+    Warning => "stroke-[var(--color-warning)]/20"
+    Error => "stroke-[var(--color-error)]/20"
+    Info => "stroke-[var(--color-info)]/20"
+  }
+}


### PR DESCRIPTION
implement a new spinner component with configurable size and color options add theme configuration for spinner styling
include example usage in demo application
<img width="1282" height="1086" alt="image" src="https://github.com/user-attachments/assets/8b249060-a2d0-469b-9b38-b93a7c3f2e7a" />
