### PR TITLE
feat(alert): add alert component

### DIFF
--- a/src/components/alert.mbt
+++ b/src/components/alert.mbt
@@ -1,0 +1,148 @@
+///|
+/// Creates a configurable alert component for displaying important messages
+/// and notifications.
+///
+/// Parameters:
+///
+/// * `children` : Array\[@html.Html\[M]] - The content to display inside the
+///   alert, such as text, icons, or other elements.
+/// * `variant` : @theme.AlertVariant - The visual style variant of the alert.
+///   Defaults to `@theme.Solid`.
+/// * `color` : @theme.AlertColor - The color theme of the alert. Defaults to
+///   `@theme.Info`.
+/// * `dismissible` : Bool - Whether the alert can be dismissed by the user.
+///   Defaults to `false`.
+/// * `icon` : @html.Html\[M]? - Optional icon to display at the beginning of
+///   the alert. Defaults to `None`.
+/// * `class` : String? - Additional CSS class name to apply to the alert.
+///   Defaults to `None`.
+///
+/// Returns an HTML div element configured with the specified properties and
+/// styling.
+///
+/// Example:
+///
+/// ```moonbit skip
+/// enum Msg {
+///   DismissAlert
+/// }
+/// 
+/// let _ = alert(
+///   [@html.text("This is an important message!")],
+///   variant=Outlined,
+///   color=Success,
+///   dismissible=true,
+///   icon=Some(@html.text("✓"))
+/// )
+/// ```
+///
+pub fn[M] alert(
+  children : Array[@html.Html[M]],
+  variant? : @theme.AlertVariant = @theme.Solid,
+  color? : @theme.AlertColor = @theme.Info,
+  dismissible? : Bool = false,
+  icon? : @html.Html[M]? = None,
+  class? : String? = None,
+) -> @html.Html[M] {
+  let klass = @theme.get_alert_style(variant~, color~, dismissible~, class~)
+  let content = []
+
+  // Add icon if provided
+  match icon {
+    Some(icon_element) => {
+      let icon_wrapper = @html.node(
+        "span",
+        [@html.attribute("class", @theme.get_alert_icon_style())],
+        [icon_element],
+      )
+      content.push(icon_wrapper)
+    }
+    None => ()
+  }
+
+  // Add main content
+  let content_wrapper = @html.node(
+    "div",
+    [@html.attribute("class", @theme.get_alert_content_style())],
+    children,
+  )
+  content.push(content_wrapper)
+
+  // Add dismiss button if dismissible
+  if dismissible {
+    let dismiss_button = @html.node(
+      "button",
+      [
+        @html.attribute("type", "button"),
+        @html.attribute("class", @theme.get_alert_dismiss_style()),
+        @html.attribute("aria-label", "Dismiss alert"),
+      ],
+      [
+        @html.node(
+          "svg",
+          [
+            @html.attribute("class", "w-4 h-4"),
+            @html.attribute("fill", "none"),
+            @html.attribute("stroke", "currentColor"),
+            @html.attribute("viewBox", "0 0 24 24"),
+          ],
+          [
+            @html.node(
+              "path",
+              [
+                @html.attribute("stroke-linecap", "round"),
+                @html.attribute("stroke-linejoin", "round"),
+                @html.attribute("stroke-width", "2"),
+                @html.attribute("d", "M6 18L18 6M6 6l12 12"),
+              ],
+              [],
+            ),
+          ],
+        ),
+      ],
+    )
+    content.push(dismiss_button)
+  }
+  let attrs = [
+    @html.attribute("role", "alert"),
+    @html.attribute("class", klass),
+  ]
+  @html.node("div", attrs, content)
+}
+
+///|
+/// Creates a simple alert with just text content.
+///
+/// Parameters:
+///
+/// * `text` : String - The text message to display in the alert.
+/// * `variant` : @theme.AlertVariant - The visual style variant of the alert.
+///   Defaults to `@theme.Solid`.
+/// * `color` : @theme.AlertColor - The color theme of the alert. Defaults to
+///   `@theme.Info`.
+/// * `dismissible` : Bool - Whether the alert can be dismissed by the user.
+///   Defaults to `false`.
+/// * `class` : String? - Additional CSS class name to apply to the alert.
+///   Defaults to `None`.
+///
+/// Returns an HTML div element with the text content.
+///
+/// Example:
+///
+/// ```moonbit skip
+/// let _ = alert_text(
+///   "Operation completed successfully!",
+///   variant=Ghost,
+///   color=Success
+/// )
+/// ```
+///
+pub fn[M] alert_text(
+  text : String,
+  variant? : @theme.AlertVariant = @theme.Solid,
+  color? : @theme.AlertColor = @theme.Info,
+  dismissible? : Bool = false,
+  class? : String? = None,
+) -> @html.Html[M] {
+  alert([@html.text(text)], variant~, color~, dismissible~, class~)
+}

--- a/src/components/pkg.generated.mbti
+++ b/src/components/pkg.generated.mbti
@@ -15,6 +15,10 @@ fn[M] accordion_item(String, @html.Html[M], @html.Html[M], variant? : @theme.Acc
 
 fn[M] accordion_trigger(Array[@html.Html[M]], M, isOpen? : Bool, color? : @theme.AccordionColor, showIcon? : Bool, class? : String?) -> @html.Html[M]
 
+fn[M] alert(Array[@html.Html[M]], variant? : @theme.AlertVariant, color? : @theme.AlertColor, dismissible? : Bool, icon? : @html.Html[M]?, class? : String?) -> @html.Html[M]
+
+fn[M] alert_text(String, variant? : @theme.AlertVariant, color? : @theme.AlertColor, dismissible? : Bool, class? : String?) -> @html.Html[M]
+
 fn[M] button(Array[@html.Html[M]], M, variant? : @theme.ButtonVariant, size? : @theme.ButtonSize, color? : @theme.ButtonColor, fullWidth? : Bool, ripple? : Bool, class? : String?) -> @html.Html[M]
 
 fn[M] button_group(Array[@html.Html[M]], orientation? : @theme.ButtonGroupOrientation, fullWidth? : Bool, class? : String?) -> @html.Html[M]

--- a/src/example/main.mbt
+++ b/src/example/main.mbt
@@ -2165,6 +2165,7 @@ fn view(model : Model) -> Html[Msg] {
         ]),
       ]),
     ]),
+    render_alert_section(model),
     render_tabs_section(model),
   ])
 }
@@ -2310,6 +2311,173 @@ fn render_tabs_section(model : Model) -> Html[Msg] {
             ],
             color=Error,
             variant=Gradient,
+          ),
+        ]),
+      ]),
+    ]),
+  ])
+}
+
+///|
+/// Renders the alert section showcasing different alert variants, colors, and features
+fn[M] render_alert_section(_model : Model) -> @html.Html[M] {
+  div(class="mb-8", [
+    h2(class="text-2xl font-bold mb-6 text-gray-800", [text("Alert Components")]),
+
+    // Alert Variants
+    div(class="mb-8", [
+      h3(class="text-lg font-semibold mb-4 text-gray-700", [
+        text("Alert Variants"),
+      ]),
+      div(class="grid grid-cols-1 md:grid-cols-2 gap-4", [
+        div(class="bg-white rounded-lg p-6 shadow-sm", [
+          h4(class="text-md font-medium mb-3 text-gray-600", [text("Solid")]),
+          div(class="space-y-3", [
+            @jade.alert_text(
+              "This is a solid alert",
+              variant=@theme.Solid,
+              color=@theme.Info,
+            ),
+            @jade.alert_text(
+              "Success message",
+              variant=@theme.Solid,
+              color=@theme.Success,
+            ),
+          ]),
+        ]),
+        div(class="bg-white rounded-lg p-6 shadow-sm", [
+          h4(class="text-md font-medium mb-3 text-gray-600", [text("Outlined")]),
+          div(class="space-y-3", [
+            @jade.alert_text(
+              "This is an outlined alert",
+              variant=@theme.Outlined,
+              color=@theme.Info,
+            ),
+            @jade.alert_text(
+              "Warning message",
+              variant=@theme.Outlined,
+              color=@theme.Warning,
+            ),
+          ]),
+        ]),
+        div(class="bg-white rounded-lg p-6 shadow-sm", [
+          h4(class="text-md font-medium mb-3 text-gray-600", [text("Ghost")]),
+          div(class="space-y-3", [
+            @jade.alert_text(
+              "This is a ghost alert",
+              variant=@theme.Ghost,
+              color=@theme.Info,
+            ),
+            @jade.alert_text(
+              "Error message",
+              variant=@theme.Ghost,
+              color=@theme.Error,
+            ),
+          ]),
+        ]),
+        div(class="bg-white rounded-lg p-6 shadow-sm", [
+          h4(class="text-md font-medium mb-3 text-gray-600", [text("Gradient")]),
+          div(class="space-y-3", [
+            @jade.alert_text(
+              "This is a gradient alert",
+              variant=@theme.Gradient,
+              color=@theme.Primary,
+            ),
+            @jade.alert_text(
+              "Secondary message",
+              variant=@theme.Gradient,
+              color=@theme.Secondary,
+            ),
+          ]),
+        ]),
+      ]),
+    ]),
+
+    // Alert Colors
+    div(class="mb-8", [
+      h3(class="text-lg font-semibold mb-4 text-gray-700", [
+        text("Alert Colors"),
+      ]),
+      div(class="bg-white rounded-lg p-6 shadow-sm", [
+        div(class="space-y-3", [
+          @jade.alert_text("Primary alert message", color=@theme.Primary),
+          @jade.alert_text("Secondary alert message", color=@theme.Secondary),
+          @jade.alert_text("Info alert message", color=@theme.Info),
+          @jade.alert_text("Success alert message", color=@theme.Success),
+          @jade.alert_text("Warning alert message", color=@theme.Warning),
+          @jade.alert_text("Error alert message", color=@theme.Error),
+        ]),
+      ]),
+    ]),
+
+    // Alert with Icons and Dismissible
+    div(class="mb-8", [
+      h3(class="text-lg font-semibold mb-4 text-gray-700", [
+        text("Alert with Icons and Dismissible"),
+      ]),
+      div(class="bg-white rounded-lg p-6 shadow-sm", [
+        div(class="space-y-3", [
+          @jade.alert(
+            [text("Alert with icon")],
+            variant=@theme.Outlined,
+            color=@theme.Success,
+            icon=Some(text("✓")),
+          ),
+          @jade.alert(
+            [text("Dismissible alert - click X to close")],
+            variant=@theme.Solid,
+            color=@theme.Warning,
+            dismissible=true,
+          ),
+          @jade.alert(
+            [text("Alert with icon and dismissible")],
+            variant=@theme.Ghost,
+            color=@theme.Error,
+            icon=Some(text("⚠")),
+            dismissible=true,
+          ),
+        ]),
+      ]),
+    ]),
+
+    // Complex Alert Content
+    div(class="mb-8", [
+      h3(class="text-lg font-semibold mb-4 text-gray-700", [
+        text("Complex Alert Content"),
+      ]),
+      div(class="bg-white rounded-lg p-6 shadow-sm", [
+        div(class="space-y-3", [
+          @jade.alert(
+            [
+              div(class="", [
+                h4(class="font-semibold mb-1", [text("Success!")]),
+                @html.p(class="text-sm", [
+                  text("Your operation has been completed successfully."),
+                ]),
+              ]),
+            ],
+            variant=@theme.Solid,
+            color=@theme.Success,
+            icon=Some(text("✓")),
+            dismissible=true,
+          ),
+          @jade.alert(
+            [
+              div(class="", [
+                h4(class="font-semibold mb-1", [text("Important Notice")]),
+                @html.p(class="text-sm mb-2", [
+                  text("Please review the following items:"),
+                ]),
+                @html.ul(class="text-sm list-disc list-inside space-y-1", [
+                  @html.li([text("Check your email for confirmation")]),
+                  @html.li([text("Update your profile information")]),
+                  @html.li([text("Review privacy settings")]),
+                ]),
+              ]),
+            ],
+            variant=@theme.Outlined,
+            color=@theme.Info,
+            icon=Some(text("ℹ")),
           ),
         ]),
       ]),

--- a/src/theme/alert.mbt
+++ b/src/theme/alert.mbt
@@ -1,0 +1,108 @@
+///|
+pub(all) enum AlertVariant {
+  Solid
+  Outlined
+  Ghost
+  Gradient
+}
+
+///|
+pub(all) enum AlertColor {
+  Primary
+  Secondary
+  Info
+  Success
+  Warning
+  Error
+}
+
+///|
+pub fn get_alert_style(
+  variant~ : AlertVariant,
+  color~ : AlertColor,
+  dismissible~ : Bool,
+  class~ : String?,
+) -> String {
+  clsx([
+    "relative w-full rounded-lg px-4 py-3 text-sm font-medium",
+    "flex items-start gap-3",
+    // Variant and color combination styles
+    match variant {
+      Solid =>
+        match color {
+          Primary =>
+            "bg-[var(--color-primary)] text-[var(--color-primary-content)]"
+          Secondary =>
+            "bg-[var(--color-secondary)] text-[var(--color-secondary-content)]"
+          Info => "bg-[var(--color-info)] text-[var(--color-info-content)]"
+          Success =>
+            "bg-[var(--color-success)] text-[var(--color-success-content)]"
+          Warning =>
+            "bg-[var(--color-warning)] text-[var(--color-warning-content)]"
+          Error => "bg-[var(--color-error)] text-[var(--color-error-content)]"
+        }
+      Outlined =>
+        match color {
+          Primary =>
+            "border border-[var(--color-primary)] bg-[var(--color-primary)]/5 text-[var(--color-primary)]"
+          Secondary =>
+            "border border-[var(--color-secondary)] bg-[var(--color-secondary)]/5 text-[var(--color-secondary)]"
+          Info =>
+            "border border-[var(--color-info)] bg-[var(--color-info)]/5 text-[var(--color-info)]"
+          Success =>
+            "border border-[var(--color-success)] bg-[var(--color-success)]/5 text-[var(--color-success)]"
+          Warning =>
+            "border border-[var(--color-warning)] bg-[var(--color-warning)]/5 text-[var(--color-warning)]"
+          Error =>
+            "border border-[var(--color-error)] bg-[var(--color-error)]/5 text-[var(--color-error)]"
+        }
+      Ghost =>
+        match color {
+          Primary => "bg-[var(--color-primary)]/10 text-[var(--color-primary)]"
+          Secondary =>
+            "bg-[var(--color-secondary)]/10 text-[var(--color-secondary)]"
+          Info => "bg-[var(--color-info)]/10 text-[var(--color-info)]"
+          Success => "bg-[var(--color-success)]/10 text-[var(--color-success)]"
+          Warning => "bg-[var(--color-warning)]/10 text-[var(--color-warning)]"
+          Error => "bg-[var(--color-error)]/10 text-[var(--color-error)]"
+        }
+      Gradient =>
+        match color {
+          Primary =>
+            "bg-gradient-to-r from-[var(--color-primary)] to-[var(--color-primary)]/80 text-[var(--color-primary-content)]"
+          Secondary =>
+            "bg-gradient-to-r from-[var(--color-secondary)] to-[var(--color-secondary)]/80 text-[var(--color-secondary-content)]"
+          Info =>
+            "bg-gradient-to-r from-[var(--color-info)] to-[var(--color-info)]/80 text-[var(--color-info-content)]"
+          Success =>
+            "bg-gradient-to-r from-[var(--color-success)] to-[var(--color-success)]/80 text-[var(--color-success-content)]"
+          Warning =>
+            "bg-gradient-to-r from-[var(--color-warning)] to-[var(--color-warning)]/80 text-[var(--color-warning-content)]"
+          Error =>
+            "bg-gradient-to-r from-[var(--color-error)] to-[var(--color-error)]/80 text-[var(--color-error-content)]"
+        }
+    },
+    // Dismissible padding adjustment
+    if dismissible {
+      "pr-10"
+    } else {
+      ""
+    },
+    class.unwrap_or(""),
+  ])
+}
+
+///|
+pub fn get_alert_icon_style() -> String {
+  "flex-shrink-0 w-5 h-5 mt-0.5"
+}
+
+///|
+pub fn get_alert_content_style() -> String {
+  "flex-1"
+}
+
+///|
+pub fn get_alert_dismiss_style() -> String {
+  "absolute top-3 right-3 p-1 rounded-md hover:bg-black/10 transition-colors"
+}

--- a/src/theme/pkg.generated.mbti
+++ b/src/theme/pkg.generated.mbti
@@ -19,6 +19,14 @@ fn get_accordion_style(variant~ : AccordionVariant, color~ : AccordionColor, cla
 
 fn get_accordion_trigger_style(color~ : AccordionColor, isOpen~ : Bool, className~ : String?) -> String
 
+fn get_alert_content_style() -> String
+
+fn get_alert_dismiss_style() -> String
+
+fn get_alert_icon_style() -> String
+
+fn get_alert_style(variant~ : AlertVariant, color~ : AlertColor, dismissible~ : Bool, class~ : String?) -> String
+
 fn get_button_group_style(orientation~ : ButtonGroupOrientation, fullWidth~ : Bool, class~ : String?) -> String
 
 fn get_button_style(variant~ : ButtonVariant, size~ : ButtonSize, color~ : ButtonColor, fullWidth~ : Bool, ripple~ : Bool, class~ : String?) -> String
@@ -99,6 +107,22 @@ pub(all) enum AccordionVariant {
   Bordered
   Shadow
   Split
+}
+
+pub(all) enum AlertColor {
+  Primary
+  Secondary
+  Info
+  Success
+  Warning
+  Error
+}
+
+pub(all) enum AlertVariant {
+  Solid
+  Outlined
+  Ghost
+  Gradient
 }
 
 pub(all) enum ButtonColor {


### PR DESCRIPTION
Implement a new alert component with support for multiple visual variants (solid, outlined, ghost, gradient) and color themes. The component includes features like dismissible alerts, custom icons, and rich content support. Also added comprehensive documentation and example usage in the demo section.
<img width="896" height="1268" alt="image" src="https://github.com/user-attachments/assets/5b0e85cc-9225-444f-a446-4c0d3b7fa6c2" />
