### PR TITLE
feat(avatar): add avatar component

### DIFF
--- a/src/components/avatar.mbt
+++ b/src/components/avatar.mbt
@@ -1,0 +1,77 @@
+///|
+/// Creates a configurable avatar component with customizable styling.
+///
+/// Parameters:
+///
+/// * `src` : String? - The image source URL. If None, displays fallback content.
+/// * `alt` : String? - Alternative text for the image. Defaults to "Avatar".
+/// * `fallback` : String? - Fallback text to display when image is not available.
+///   If None, uses the first character of alt text.
+/// * `size` : @theme.AvatarSize - The size of the avatar. Defaults to `@theme.Md`.
+/// * `shape` : @theme.AvatarShape - The shape of the avatar. Defaults to `@theme.Circle`.
+/// * `color` : @theme.AvatarColor - The color theme for fallback display. Defaults to `@theme.Neutral`.
+/// * `class` : String? - Additional CSS class name to apply to the avatar.
+///   Defaults to `None`.
+///
+/// Returns an HTML element configured with the specified properties and styling.
+///
+/// Example:
+///
+/// ```moonbit skip
+/// // Avatar with image
+/// let _ = avatar(
+///   src="https://example.com/user.jpg",
+///   alt="John Doe",
+///   size=Lg,
+///   shape=Circle
+/// )
+///
+/// // Avatar with fallback text
+/// let _ = avatar(
+///   fallback="JD",
+///   alt="John Doe",
+///   size=Md,
+///   color=Primary
+/// )
+/// ```
+///
+pub fn[M] avatar(
+  src? : String,
+  alt? : String,
+  fallback? : String,
+  size? : @theme.AvatarSize = @theme.Md,
+  shape? : @theme.AvatarShape = @theme.Circle,
+  color? : @theme.AvatarColor = @theme.Neutral,
+  class? : String,
+) -> @html.Html[M] {
+  let container_style = @theme.get_avatar_style(size~, shape~, color~, class?)
+  match src {
+    Some(_) => {
+      let image_style = @theme.get_avatar_image_style(shape~)
+      @html.div(class=container_style, [
+        @html.img(src?, alt?, class=image_style, []),
+      ])
+    }
+    None => {
+      let display_text = match fallback {
+        Some(text) => text
+        None =>
+          match alt {
+            Some(alt_text) =>
+              // Get first character of alt text, or "?" if empty
+              if alt_text.length() > 0 {
+                let first_char = alt_text.get(0)
+                match first_char {
+                  Some(c) => c.to_string().to_upper()
+                  None => "?"
+                }
+              } else {
+                "?"
+              }
+            None => "?"
+          }
+      }
+      @html.div(class=container_style, [@html.text(display_text)])
+    }
+  }
+}

--- a/src/components/pkg.generated.mbti
+++ b/src/components/pkg.generated.mbti
@@ -15,6 +15,8 @@ fn[M] accordion_item(String, @html.Html[M], @html.Html[M], variant? : @theme.Acc
 
 fn[M] accordion_trigger(Array[@html.Html[M]], M, isOpen? : Bool, color? : @theme.AccordionColor, showIcon? : Bool, class? : String?) -> @html.Html[M]
 
+fn[M] avatar(src? : String, alt? : String, fallback? : String, size? : @theme.AvatarSize, shape? : @theme.AvatarShape, color? : @theme.AvatarColor, class? : String) -> @html.Html[M]
+
 fn[M] button(Array[@html.Html[M]], M, variant? : @theme.ButtonVariant, size? : @theme.ButtonSize, color? : @theme.ButtonColor, fullWidth? : Bool, ripple? : Bool, class? : String?) -> @html.Html[M]
 
 fn[M] button_group(Array[@html.Html[M]], orientation? : @theme.ButtonGroupOrientation, fullWidth? : Bool, class? : String?) -> @html.Html[M]

--- a/src/example/main.mbt
+++ b/src/example/main.mbt
@@ -2165,6 +2165,7 @@ fn view(model : Model) -> Html[Msg] {
         ]),
       ]),
     ]),
+    render_avatar_section(model),
     render_tabs_section(model),
   ])
 }
@@ -2177,19 +2178,10 @@ fn render_tabs_section(model : Model) -> Html[Msg] {
   @html.div([
     @jade.card(
       [
-        @jade.card_header([
-          @jade.typography(tag=@theme.H2, color=@theme.Default, [
-            text("Tabs Component Styles"),
-          ]),
-        ]),
+        @jade.card_header([@jade.typography([text("Tabs Component Styles")])]),
         @jade.card_body(
           [
-            @jade.typography(
-              tag=@theme.H3,
-              color=@theme.Default,
-              class="mb-4",
-              [text("Tab Variants")],
-            ),
+            @jade.typography(class="mb-4", [text("Tab Variants")]),
             ..variants.map(variant => @html.div(class="space-y-8", [
               // Default 变体
               @jade.card(
@@ -2314,6 +2306,100 @@ fn render_tabs_section(model : Model) -> Html[Msg] {
         ]),
       ]),
     ]),
+  ])
+}
+
+///|
+/// Avatar 组件展示区域
+fn render_avatar_section(_model : Model) -> Html[Msg] {
+  @html.div([
+    @jade.card(
+      [
+        @jade.card_header([@jade.typography([text("Avatar Component Styles")])]),
+        @jade.card_body([
+          // Avatar 尺寸展示
+          @jade.typography(class="mb-4", [text("Avatar Sizes")]),
+          @html.div(class="flex items-center gap-4 mb-8", [
+            @jade.avatar(
+              src="https://images.unsplash.com/photo-1472099645785-5658abf4ff4e?w=150",
+              alt="User Avatar",
+              fallback="U",
+              size=@theme.Xs,
+            ),
+            @jade.avatar(
+              src="https://images.unsplash.com/photo-1472099645785-5658abf4ff4e?w=150",
+              alt="User Avatar",
+              fallback="U",
+              size=@theme.Sm,
+            ),
+            @jade.avatar(
+              src="https://images.unsplash.com/photo-1472099645785-5658abf4ff4e?w=150",
+              alt="User Avatar",
+              fallback="U",
+              size=@theme.Md,
+            ),
+            @jade.avatar(
+              src="https://images.unsplash.com/photo-1472099645785-5658abf4ff4e?w=150",
+              alt="User Avatar",
+              fallback="U",
+              size=@theme.Lg,
+            ),
+            @jade.avatar(
+              src="https://images.unsplash.com/photo-1472099645785-5658abf4ff4e?w=150",
+              alt="User Avatar",
+              fallback="U",
+              size=@theme.Xl,
+            ),
+          ]),
+
+          // Avatar 形状展示
+          @jade.typography(tag=@theme.H3, color=@theme.Default, class="mb-4", [
+            text("Avatar Shapes"),
+          ]),
+          @html.div(class="flex items-center gap-4 mb-8", [
+            @jade.avatar(
+              src="https://images.unsplash.com/photo-1472099645785-5658abf4ff4e?w=150",
+              alt="Round Avatar",
+              fallback="R",
+              size=@theme.Lg,
+              shape=@theme.Circle,
+            ),
+            @jade.avatar(
+              src="https://images.unsplash.com/photo-1472099645785-5658abf4ff4e?w=150",
+              alt="Square Avatar",
+              fallback="S",
+              size=@theme.Lg,
+              shape=@theme.Square,
+            ),
+          ]),
+
+          // Avatar 颜色展示
+          @jade.typography(tag=@theme.H3, color=@theme.Default, class="mb-4", [
+            text("Avatar Colors (Fallback)"),
+          ]),
+          @html.div(class="flex items-center gap-4 mb-8", [
+            @jade.avatar(fallback="P", size=@theme.Lg, color=@theme.Primary),
+            @jade.avatar(fallback="S", size=@theme.Lg, color=@theme.Secondary),
+            @jade.avatar(fallback="I", size=@theme.Lg, color=@theme.Info),
+            @jade.avatar(fallback="S", size=@theme.Lg, color=@theme.Success),
+            @jade.avatar(fallback="W", size=@theme.Lg, color=@theme.Warning),
+            @jade.avatar(fallback="E", size=@theme.Lg, color=@theme.Error),
+          ]),
+
+          // Avatar 回退文本展示
+          @jade.typography(tag=@theme.H3, color=@theme.Default, class="mb-4", [
+            text("Avatar Fallback Examples"),
+          ]),
+          @html.div(class="flex items-center gap-4 mb-8", [
+            @jade.avatar(fallback="JD", size=@theme.Lg, color=@theme.Primary),
+            @jade.avatar(fallback="AB", size=@theme.Lg, color=@theme.Secondary),
+            @jade.avatar(fallback="XY", size=@theme.Lg, color=@theme.Success),
+          ]),
+        ]),
+      ],
+      variant=@theme.Solid,
+      color=@theme.Default,
+    ),
   ])
 }
 

--- a/src/theme/avatar.mbt
+++ b/src/theme/avatar.mbt
@@ -1,0 +1,73 @@
+///|
+pub(all) enum AvatarSize {
+  Xs
+  Sm
+  Md
+  Lg
+  Xl
+}
+
+///|
+pub(all) enum AvatarShape {
+  Circle
+  Square
+}
+
+///|
+pub(all) enum AvatarColor {
+  Primary
+  Secondary
+  Info
+  Success
+  Warning
+  Error
+  Neutral
+}
+
+///|
+pub fn get_avatar_style(
+  size~ : AvatarSize,
+  shape~ : AvatarShape,
+  color~ : AvatarColor,
+  class? : String,
+) -> String {
+  clsx([
+    "inline-flex items-center justify-center overflow-hidden bg-gray-100 font-medium text-gray-600 select-none",
+    // Size styles
+    match size {
+      Xs => "w-6 h-6 text-xs"
+      Sm => "w-8 h-8 text-sm"
+      Md => "w-10 h-10 text-base"
+      Lg => "w-12 h-12 text-lg"
+      Xl => "w-16 h-16 text-xl"
+    },
+    // Shape styles
+    match shape {
+      Circle => "rounded-full"
+      Square => "rounded-md"
+    },
+    // Color styles
+    match color {
+      Primary => "bg-[var(--color-primary)] text-[var(--color-primary-content)]"
+      Secondary =>
+        "bg-[var(--color-secondary)] text-[var(--color-secondary-content)]"
+      Info => "bg-[var(--color-info)] text-[var(--color-info-content)]"
+      Success => "bg-[var(--color-success)] text-[var(--color-success-content)]"
+      Warning => "bg-[var(--color-warning)] text-[var(--color-warning-content)]"
+      Error => "bg-[var(--color-error)] text-[var(--color-error-content)]"
+      Neutral => "bg-[var(--color-neutral)] text-[var(--color-neutral-content)]"
+    },
+    class.unwrap_or(""),
+  ])
+}
+
+///|
+pub fn get_avatar_image_style(shape~ : AvatarShape) -> String {
+  clsx([
+    "w-full h-full object-cover",
+    match shape {
+      Circle => "rounded-full"
+      Square => "rounded-md"
+    },
+  ])
+}

--- a/src/theme/pkg.generated.mbti
+++ b/src/theme/pkg.generated.mbti
@@ -19,6 +19,10 @@ fn get_accordion_style(variant~ : AccordionVariant, color~ : AccordionColor, cla
 
 fn get_accordion_trigger_style(color~ : AccordionColor, isOpen~ : Bool, className~ : String?) -> String
 
+fn get_avatar_image_style(shape~ : AvatarShape) -> String
+
+fn get_avatar_style(size~ : AvatarSize, shape~ : AvatarShape, color~ : AvatarColor, class? : String) -> String
+
 fn get_button_group_style(orientation~ : ButtonGroupOrientation, fullWidth~ : Bool, class~ : String?) -> String
 
 fn get_button_style(variant~ : ButtonVariant, size~ : ButtonSize, color~ : ButtonColor, fullWidth~ : Bool, ripple~ : Bool, class~ : String?) -> String
@@ -99,6 +103,29 @@ pub(all) enum AccordionVariant {
   Bordered
   Shadow
   Split
+}
+
+pub(all) enum AvatarColor {
+  Primary
+  Secondary
+  Info
+  Success
+  Warning
+  Error
+  Neutral
+}
+
+pub(all) enum AvatarShape {
+  Circle
+  Square
+}
+
+pub(all) enum AvatarSize {
+  Xs
+  Sm
+  Md
+  Lg
+  Xl
 }
 
 pub(all) enum ButtonColor {


### PR DESCRIPTION

<img width="874" height="1074" alt="image" src="https://github.com/user-attachments/assets/dd04b2e5-9140-4fb2-a793-597bd4b45ab0" />


Implement a new avatar component that supports:
- Image display with fallback text
- Customizable sizes (xs, sm, md, lg, xl)
- Shape options (circle, square)
- Color themes for fallback display
- Example showcase in demo page